### PR TITLE
Fix DbEntitySet creation in artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,3 +287,6 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+SqlMetal.exe
+DataClasses.dbml

--- a/Deblazer.Artifacts/ArtifactClass.fs
+++ b/Deblazer.Artifacts/ArtifactClass.fs
@@ -692,9 +692,7 @@
                                                                     )))))
                                                 ) :> StatementSyntax
                                             |]
-                                        )) :> StatementSyntax
-                                |]))
-                            .WithElse(
+                                        )).WithElse(
                                 sf.ElseClause(
                                     sf.ExpressionStatement(
                                         sf.AssignmentExpression(
@@ -873,6 +871,7 @@
                                                                 sf.Token(sk.CommaToken)
                                                                 sf.Token(sk.CommaToken)
                                                             |]))))))) :> StatementSyntax
+                                |])) :> StatementSyntax
                         sf.ReturnStatement(sf.IdentifierName(association.Storage)) :> StatementSyntax
                     |]))
     //sf.AccessorDeclaration(sk.SetAccessorDeclaration).WithBody(

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ sqlmetal.exe /conn:"Data Source=MySQlServer;Initial Catalog=MyDatabase;Integrate
 ```
 3. Generate Artifacts
 ```sh
-deblazer.artifacts.exe DataClasses.dbml -dbml <Path to DBML File> -o <OutputPath>
+deblazer.artifacts.exe -dbml <Path to DBML File> -o <OutputPath>
 ```
 
 4. Add the files to a .csproj


### PR DESCRIPTION
Brackets were not on right position, leaving 1:N-properties NULL if they don't access the cache (_getChildrenFromCache). Tried to fix that...