### PR TITLE
Treat warnings as errors

### DIFF
--- a/Deblazer.Artifacts.Test/Deblazer.Artifacts.Test.fsproj
+++ b/Deblazer.Artifacts.Test/Deblazer.Artifacts.Test.fsproj
@@ -15,6 +15,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Name>Deblazer.DataClasses.Test</Name>
     <TargetFrameworkProfile />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Deblazer.Artifacts/Deblazer.Artifacts.fsproj
+++ b/Deblazer.Artifacts/Deblazer.Artifacts.fsproj
@@ -14,6 +14,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Name>Deblazer.Artifacs</Name>
     <TargetFrameworkProfile />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Travis-CI should fail when we have warnings in the code. 